### PR TITLE
Force filter value to string

### DIFF
--- a/src/proxy/Records.js
+++ b/src/proxy/Records.js
@@ -150,7 +150,7 @@ Ext.define('Emergence.proxy.Records', {
 
         for (; i < length; i++) {
             filterData = filters[i].serialize();
-            filterValue = filterData.value;
+            filterValue = filterData.value.toString();
             out[i] = filterData.property+ ':' + (filterValue.match(/\s/) ? '"' + filterValue + '"' : filterValue);
         }
 


### PR DESCRIPTION
This should avoid "filterValue.match is not a function" errors on
the subsequent line when the filter value is numeric rather than
a string.
