### PR TITLE
Add unauthenticated and failure request callbacks

### DIFF
--- a/src/util/AbstractAPI.js
+++ b/src/util/AbstractAPI.js
@@ -55,6 +55,12 @@ Ext.define('Emergence.util.AbstractAPI', {
             },
             exception: function(response) {
                 Ext.callback(callback, scope, [false, response]);
+            },
+            unauthenticated: function(response) {
+                Ext.callback(callback, scope, [false, response]);
+            },
+            failure: function(response) {
+                Ext.callback(callback, scope, [false, response]);
             }
         });
     },
@@ -88,6 +94,12 @@ Ext.define('Emergence.util.AbstractAPI', {
             },
             exception: function(response) {
                 Ext.callback(callback, scope, [false, response]);
+            },
+            unauthenticated: function(response) {
+                Ext.callback(callback, scope, [false, response]);
+            },
+            failure: function(response) {
+                Ext.callback(callback, scope, [false, response]);
             }
         });
     },
@@ -105,6 +117,12 @@ Ext.define('Emergence.util.AbstractAPI', {
                 this.fireEvent('logout', response.data);
             },
             exception: function(response) {
+                Ext.callback(callback, scope, [false, response]);
+            },
+            unauthenticated: function(response) {
+                Ext.callback(callback, scope, [false, response]);
+            },
+            failure: function(response) {
                 Ext.callback(callback, scope, [false, response]);
             }
         });


### PR DESCRIPTION
@themightychris I'm not sure if adding these two is totally necessary but it works with the PR I made on the Jarvus api kit.

https://github.com/JarvusInnovations/jarvus-apikit/pull/4

Basically I'm allowing any failed or unauthenticated requests to go right back to the relevant callback which can handle showing a login for etc.
